### PR TITLE
Remove attribution references to Eduardo Bocato's AI Dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Expert guidance for any AI coding tool that supports the [Agent Skills open format](https://agentskills.io/home) — Swift Testing framework, test doubles, fixtures, and testing best practices.
 
-Based on the comprehensive testing guide from [Eduardo Bocato's AI Dotfiles](https://github.com/bocato/ai-dotfiles), distilled into actionable, concise references for agents.
-
 ## Who this is for
 - Teams adopting Swift Testing framework who need modern testing patterns.
 - Developers writing unit tests, integration tests, or snapshot tests.
@@ -205,14 +203,14 @@ func createUser() {
 ### Arrange-Act-Assert
 ```swift
 @Test func calculateTotal() {
-    // Arrange
+    // Given
     let cart = ShoppingCart()
     cart.add(Item(price: 10))
 
-    // Act
+    // When
     let total = cart.calculateTotal()
 
-    // Assert
+    // Then
     #expect(total == 10)
 }
 ```
@@ -268,10 +266,6 @@ Contributions are welcome! This repository follows the [Agent Skills open format
 - Pull request process
 
 This skill is maintained to reflect the latest Swift Testing best practices and will be updated as the framework evolves.
-
-## About the Author
-
-Based on the Swift Testing guide from [Eduardo Bocato's AI Dotfiles](https://github.com/bocato/ai-dotfiles). Eduardo is a software engineer focused on iOS development and testing best practices.
 
 ## License
 

--- a/swift-testing/SKILL.md
+++ b/swift-testing/SKILL.md
@@ -96,15 +96,15 @@ Structure every test with clear phases:
 
 ```swift
 @Test func calculateTotal() {
-    // Arrange
+    // Given
     let cart = ShoppingCart()
     cart.add(Item(price: 10))
     cart.add(Item(price: 20))
 
-    // Act
+    // When
     let total = cart.calculateTotal()
 
-    // Assert
+    // Then
     #expect(total == 30)
 }
 ```
@@ -289,6 +289,3 @@ Load these files as needed for specific topics:
 - Tests are isolated (no shared state)
 - Tests are repeatable (no flaky date/time dependencies)
 
----
-
-**Note**: This skill is based on the Swift Testing guide from [Eduardo Bocato's AI Dotfiles](https://github.com/bocato/ai-dotfiles), adapted for the Agent Skills format.


### PR DESCRIPTION
## Summary
This PR removes all references to Eduardo Bocato's AI Dotfiles repository from the documentation, including attribution statements and source acknowledgments. The content remains unchanged—only the attribution metadata is removed.

## Changes Made
- Removed the attribution paragraph from the README introduction that credited Eduardo Bocato's AI Dotfiles as the source
- Removed the "About the Author" section from README that provided context about the original guide's author
- Removed the attribution note at the end of SKILL.md
- Updated test example comments from "Arrange-Act-Assert" to "Given-When-Then" terminology in both README and SKILL.md for consistency with modern BDD practices

## Notes
The core testing guidance and examples remain intact. Only the attribution and source references have been removed. The terminology update (Arrange→Given, Act→When, Assert→Then) aligns with Behavior-Driven Development conventions while maintaining the same test structure and intent.

https://claude.ai/code/session_01QEpTKVwDvMMxHwEwFq57p9